### PR TITLE
Use from command palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # fuchsia-git-helper README
 
-Simple extension for quick-opening fuchsia.git files in Gitiles. 
+Simple extension for quick-opening fuchsia.git files in Gitiles.
 
 ## How to use:
 
 Right click inside the text editor or on file/folder in the explorer pane,
 then select "Open in Gitiles".
+Or, use the command palette and select "Open in Gitiles".
 
 Note: this assumes the root of your workspace is also the root of fuchsia.git,
 and opening links will break if this assumption doesn't hold.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,10 @@
 
 Simple extension for quick-opening fuchsia.git files in Gitiles. 
 
+## How to use:
+
+Right click inside the text editor or on file/folder in the explorer pane,
+then select "Open in Gitiles".
+
 Note: this assumes the root of your workspace is also the root of fuchsia.git,
 and opening links will break if this assumption doesn't hold.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "fuchsia-git-helper",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -56,14 +56,6 @@
 			],
 			"commandPalette": [
 				{
-					"command": "fuchsia-git-helper.openAtRevision",
-					"when": "false"
-				},
-				{
-					"command": "fuchsia-git-helper.openAtMaster",
-					"when": "false"
-				},
-				{
 					"command": "fuchsia-git-helper.openAtRevisionFromExplorer",
 					"when": "false"
 				},

--- a/package.json
+++ b/package.json
@@ -53,6 +53,24 @@
 				{
 					"command": "fuchsia-git-helper.openAtMasterFromExplorer"
 				}
+			],
+			"commandPalette": [
+				{
+					"command": "fuchsia-git-helper.openAtRevision",
+					"when": "false"
+				},
+				{
+					"command": "fuchsia-git-helper.openAtMaster",
+					"when": "false"
+				},
+				{
+					"command": "fuchsia-git-helper.openAtRevisionFromExplorer",
+					"when": "false"
+				},
+				{
+					"command": "fuchsia-git-helper.openAtMasterFromExplorer",
+					"when": "false"
+				}
 			]
 		}
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,6 @@ type ContextMenuCommandArg = {
 type CommandArg = ContextMenuCommandArg | undefined;
 
 function getPathSegment(arg: CommandArg) {
-	debugger;
 	let root = vscode.workspace.rootPath;
 
 	let fullPath =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,17 +5,29 @@
 import * as vscode from 'vscode';
 import { Commit, GitExtension } from "./git.d";
 
-
 const BASE = "https://fuchsia.googlesource.com/fuchsia/+/";
-const MASTER = "refs/heads/master"
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
+const MASTER = "refs/heads/master";
 
-function getPathSegment(pathObj: any) {
-	let path = pathObj.path;
+// The object received when the extension is called from context-menu / right click
+type ContextMenuCommandArg = {
+	path: string,
+};
+
+// When the extension is called from context menu, we get a PathObj argument. When it is called
+// from the command palette, we get an unedfined argument
+type CommandArg = ContextMenuCommandArg | undefined;
+
+function getPathSegment(arg: CommandArg) {
+	debugger;
 	let root = vscode.workspace.rootPath;
 
-	return path.slice(root?.length);
+	let fullPath =
+		arg?.path || // Try to use the passed in path, if available
+		vscode.window.activeTextEditor?.document.fileName || // Fallback to the active editor's path
+		root || // Fallback to the root of the workspace
+		'';
+
+	return fullPath.slice(root?.length);
 }
 
 function getLineSegment() {
@@ -27,8 +39,8 @@ function getLineSegment() {
 	return "";
 }
 
-function openAtRevision(pathObj: any, includeLineNumber: boolean) {
-	let cutPath = getPathSegment(pathObj);
+function openAtRevision(arg: CommandArg, includeLineNumber: boolean) {
+	let cutPath = getPathSegment(arg);
 	let line = "";
 	if (includeLineNumber) {
 		line = getLineSegment();
@@ -46,8 +58,8 @@ function openAtRevision(pathObj: any, includeLineNumber: boolean) {
 	});
 }
 
-function openAtMaster(pathObj: any, includeLineNumber: boolean) {
-	let cutPath = getPathSegment(pathObj);
+function openAtMaster(arg: CommandArg, includeLineNumber: boolean) {
+	let cutPath = getPathSegment(arg);
 	let line = "";
 	if (includeLineNumber) {
 		line = getLineSegment();
@@ -60,17 +72,17 @@ export function activate(context: vscode.ExtensionContext) {
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json
-	context.subscriptions.push(vscode.commands.registerCommand('fuchsia-git-helper.openAtRevision', (pathObj) => {
-		openAtRevision(pathObj, true);
+	context.subscriptions.push(vscode.commands.registerCommand('fuchsia-git-helper.openAtRevision', (arg) => {
+		openAtRevision(arg, true);
 	}));
-	context.subscriptions.push(vscode.commands.registerCommand('fuchsia-git-helper.openAtRevisionFromExplorer', (pathObj) => {
-		openAtRevision(pathObj, false);
+	context.subscriptions.push(vscode.commands.registerCommand('fuchsia-git-helper.openAtRevisionFromExplorer', (arg) => {
+		openAtRevision(arg, false);
 	}));
-	context.subscriptions.push(vscode.commands.registerCommand('fuchsia-git-helper.openAtMaster', (pathObj) => {
-		openAtMaster(pathObj, true);
+	context.subscriptions.push(vscode.commands.registerCommand('fuchsia-git-helper.openAtMaster', (arg) => {
+		openAtMaster(arg, true);
 	}));
-	context.subscriptions.push(vscode.commands.registerCommand('fuchsia-git-helper.openAtMasterFromExplorer', (pathObj) => {
-		openAtMaster(pathObj, false);
+	context.subscriptions.push(vscode.commands.registerCommand('fuchsia-git-helper.openAtMasterFromExplorer', (arg) => {
+		openAtMaster(arg, false);
 	}));
 }
 


### PR DESCRIPTION
This PR makes the extension work from the command palette, where there is no PathObj passed in by VSCode. It also hides the "open from explorer" variant of the commands from the command palette.